### PR TITLE
Add path in runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ COPY --from=builder /etc/profile.d /etc/profile.d
 COPY --from=builder /opt/scripts /opt/scripts
 
 RUN chown -R nobody:nobody /opt
+ENV PATH=/opt/scripts/:$PATH
 
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["bash", "-c", "$RELEASE_NAME start"]


### PR DESCRIPTION
Issue: #10 

### Description

- Add `entrypoint.sh` to path in runtime stage.

Tested local, with example Project.