### PR TITLE
add libstdc++ and libgcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir $HOME
 WORKDIR $HOME
 
 RUN apk --no-cache --update-cache --available upgrade \
-    && apk add --no-cache --update-cache bash ca-certificates build-base git inotify-tools nodejs npm yarn \
+    && apk add --no-cache --update-cache bash ca-certificates libstdc++ libgcc build-base git inotify-tools nodejs npm yarn \
     && mix do local.hex --force, local.rebar --force \
     && update-ca-certificates --fresh
 
@@ -41,7 +41,7 @@ RUN mkdir $HOME
 WORKDIR $HOME
 
 RUN apk --no-cache --update-cache --available upgrade \
-    && apk add --no-cache --update-cache bash ca-certificates openssl ncurses-libs \
+    && apk add --no-cache --update-cache bash ca-certificates libstdc++ libgcc openssl ncurses-libs \
     && update-ca-certificates --fresh
 
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
This fixes error `beam.smp: symbol not found`. Example output:

```
Error loading shared library libstdc++.so.6: No such file or directory (needed by /opt/app/_build/prod/rel/myproject/erts-12.0.1/bin/beam.smp)
Error loading shared library libgcc_s.so.1: No such file or directory (needed by /opt/app/_build/prod/rel/myproject/erts-12.0.1/bin/beam.smp)
Error relocating /opt/app/_build/prod/rel/myproject/erts-12.0.1/bin/beam.smp: __cxa_begin_catch: symbol not found
...
```