### PR TITLE
remove libgcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir $HOME
 WORKDIR $HOME
 
 RUN apk --no-cache --update-cache --available upgrade \
-    && apk add --no-cache --update-cache bash ca-certificates libstdc++ libgcc build-base git inotify-tools nodejs npm yarn \
+    && apk add --no-cache --update-cache bash ca-certificates libstdc++ build-base git inotify-tools nodejs npm yarn \
     && mix do local.hex --force, local.rebar --force \
     && update-ca-certificates --fresh
 
@@ -41,7 +41,7 @@ RUN mkdir $HOME
 WORKDIR $HOME
 
 RUN apk --no-cache --update-cache --available upgrade \
-    && apk add --no-cache --update-cache bash ca-certificates libstdc++ libgcc openssl ncurses-libs \
+    && apk add --no-cache --update-cache bash ca-certificates libstdc++ openssl ncurses-libs \
     && update-ca-certificates --fresh
 
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
> `libgcc` is not needed because `libstdc++` depends on it:
> https://pkgs.alpinelinux.org/package/edge/main/x86/libstdc++

https://github.com/sourceboat/docker-phoenix/pull/21#discussion_r655910425
